### PR TITLE
Simplify injecting the version-number into the aar filename

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.5.0'
     }
 }
 
@@ -26,14 +26,8 @@ android {
         }
     }
 
-    libraryVariants.all { variant ->
-        variant.outputs.each { output ->
-            def outputFile = output.outputFile
-            if (outputFile != null && outputFile.name.endsWith('.aar')) {
-                def fileName = "${archivesBaseName}-${version}.aar"
-                output.outputFile = new File(outputFile.parent, fileName)
-            }
-        }
+    defaultConfig {
+        archivesBaseName += "-$version"
     }
 }
 


### PR DESCRIPTION
Also bump build-tools plugin to 1.5.0 as this approach was not working before this version

Info: it introduces a functional change as now build-type ( and flavors when they would be used ) is then also part of the filename - there might be a way to work-around this - but I see this as a feature and not a bug.

output of gradle clean build before:
 ./android/build/outputs/aar/axolotl-android-1.3.4.aar

now:
./android/build/outputs/aar/axolotl-android-1.3.4-release.aar
./android/build/outputs/aar/axolotl-android-1.3.4-debug.aar

context: http://stackoverflow.com/a/33707064/322642
