### PR TITLE
Wrap upload tasks in a check for sonatypeRepo

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,6 +54,7 @@ signing {
     sign configurations.archives
 }
 
+if(project.hasProperty('sonatypeRepo')) {
 uploadArchives {
     configuration = configurations.archives
     repositories.mavenDeployer {
@@ -90,6 +91,7 @@ uploadArchives {
             }
         }
     }
+}
 }
 
 task installArchives(type: Upload) {

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -42,6 +42,7 @@ signing {
     sign configurations.archives
 }
 
+if(project.hasProperty('sonatypeRepo')) {
 uploadArchives {
     configuration = configurations.archives
     repositories.mavenDeployer {
@@ -78,6 +79,7 @@ uploadArchives {
             }
         }
     }
+}
 }
 
 task installArchives(type: Upload) {


### PR DESCRIPTION
This lets the library compile from a fresh GitHub checkout; otherwise
you need to set up a gradle.properties locally.