### PR TITLE
Add toString to SenderKeyName

### DIFF
--- a/java/src/main/java/org/whispersystems/libsignal/groups/SenderKeyName.java
+++ b/java/src/main/java/org/whispersystems/libsignal/groups/SenderKeyName.java
@@ -49,4 +49,8 @@ public class SenderKeyName {
     return this.groupId.hashCode() ^ this.sender.hashCode();
   }
 
+  @Override
+  public String toString() {
+    return groupId + ":" + sender.getName() + ":" + sender.getDeviceId();
+  }
 }


### PR DESCRIPTION
Fixes various issues where `toString()` is used to make intelligible exceptions.

```
Caused by: org.whispersystems.libsignal.NoSessionException: No sender key for: org.whispersystems.libsignal.groups.SenderKeyName@6450adf3
	at org.whispersystems.libsignal.groups.GroupCipher.decrypt(GroupCipher.java:123)
	at org.whispersystems.libsignal.groups.GroupCipher.decrypt(GroupCipher.java:96)
```