### PR TITLE
Make keys compatible with Java framework

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -34,14 +34,14 @@ sourceSets {
 
 dependencies {
     compile "org.whispersystems:curve25519-java:${curve25519_version}"
-    compile 'com.google.protobuf:protobuf-javalite:3.10.0'
+    compile 'com.google.protobuf:protobuf-java:3.17.3'
 
     testCompile ('junit:junit:3.8.2')
 }
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.10.0'
+        artifact = 'com.google.protobuf:protoc:3.17.3'
     }
     generateProtoTasks {
         all().each { task ->

--- a/java/src/main/java/org/whispersystems/libsignal/ecc/Curve.java
+++ b/java/src/main/java/org/whispersystems/libsignal/ecc/Curve.java
@@ -71,8 +71,8 @@ public class Curve {
 
     if (publicKey.getType() == DJB_TYPE) {
       return Curve25519.getInstance(BEST)
-                       .calculateAgreement(((DjbECPublicKey) publicKey).getPublicKey(),
-                                           ((DjbECPrivateKey) privateKey).getPrivateKey());
+                       .calculateAgreement(((DjbECPublicKey) publicKey).getEncoded(),
+                                           ((DjbECPrivateKey) privateKey).getEncoded());
     } else {
       throw new InvalidKeyException("Unknown type: " + publicKey.getType());
     }
@@ -87,7 +87,7 @@ public class Curve {
 
     if (signingKey.getType() == DJB_TYPE) {
       return Curve25519.getInstance(BEST)
-                       .verifySignature(((DjbECPublicKey) signingKey).getPublicKey(), message, signature);
+                       .verifySignature(((DjbECPublicKey) signingKey).getEncoded(), message, signature);
     } else {
       throw new InvalidKeyException("Unknown type: " + signingKey.getType());
     }
@@ -102,7 +102,7 @@ public class Curve {
 
     if (signingKey.getType() == DJB_TYPE) {
       return Curve25519.getInstance(BEST)
-                       .calculateSignature(((DjbECPrivateKey) signingKey).getPrivateKey(), message);
+                       .calculateSignature(((DjbECPrivateKey) signingKey).getEncoded(), message);
     } else {
       throw new InvalidKeyException("Unknown type: " + signingKey.getType());
     }
@@ -117,7 +117,7 @@ public class Curve {
 
     if (signingKey.getType() == DJB_TYPE) {
       return Curve25519.getInstance(BEST)
-                       .calculateVrfSignature(((DjbECPrivateKey)signingKey).getPrivateKey(), message);
+                       .calculateVrfSignature(((DjbECPrivateKey)signingKey).getEncoded(), message);
     } else {
       throw new InvalidKeyException("Unknown type: " + signingKey.getType());
     }
@@ -132,7 +132,7 @@ public class Curve {
 
     if (signingKey.getType() == DJB_TYPE) {
       return Curve25519.getInstance(BEST)
-                       .verifyVrfSignature(((DjbECPublicKey) signingKey).getPublicKey(), message, signature);
+                       .verifyVrfSignature(((DjbECPublicKey) signingKey).getEncoded(), message, signature);
     } else {
       throw new InvalidKeyException("Unknown type: " + signingKey.getType());
     }

--- a/java/src/main/java/org/whispersystems/libsignal/ecc/DjbECPrivateKey.java
+++ b/java/src/main/java/org/whispersystems/libsignal/ecc/DjbECPrivateKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2016 Open Whisper Systems
  *
  * Licensed according to the LICENSE file in this repository.
@@ -15,8 +15,23 @@ public class DjbECPrivateKey implements ECPrivateKey {
   }
 
   @Override
+  public String getAlgorithm() {
+    return "Curve25519";
+  }
+
+  @Override
+  public String getFormat() {
+    return "RAW";
+  }
+
+  @Override
+  public byte[] getEncoded() {
+    return this.privateKey;
+  }
+
+  @Override
   public byte[] serialize() {
-    return privateKey;
+    return this.privateKey;
   }
 
   @Override
@@ -24,7 +39,4 @@ public class DjbECPrivateKey implements ECPrivateKey {
     return Curve.DJB_TYPE;
   }
 
-  public byte[] getPrivateKey() {
-    return privateKey;
-  }
 }

--- a/java/src/main/java/org/whispersystems/libsignal/ecc/DjbECPublicKey.java
+++ b/java/src/main/java/org/whispersystems/libsignal/ecc/DjbECPublicKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2016 Open Whisper Systems
  *
  * Licensed according to the LICENSE file in this repository.
@@ -20,9 +20,24 @@ public class DjbECPublicKey implements ECPublicKey {
   }
 
   @Override
+  public String getAlgorithm() {
+    return "Curve25519";
+  }
+
+  @Override
+  public String getFormat() {
+    return "RAW";
+  }
+
+  @Override
+  public byte[] getEncoded() {
+    return this.publicKey;
+  }
+
+  @Override
   public byte[] serialize() {
     byte[] type = {Curve.DJB_TYPE};
-    return ByteUtil.combine(type, publicKey);
+    return ByteUtil.combine(type, this.publicKey);
   }
 
   @Override
@@ -49,7 +64,4 @@ public class DjbECPublicKey implements ECPublicKey {
     return new BigInteger(publicKey).compareTo(new BigInteger(((DjbECPublicKey)another).publicKey));
   }
 
-  public byte[] getPublicKey() {
-    return publicKey;
-  }
 }

--- a/java/src/main/java/org/whispersystems/libsignal/ecc/ECKeyPair.java
+++ b/java/src/main/java/org/whispersystems/libsignal/ecc/ECKeyPair.java
@@ -1,25 +1,29 @@
-/**
+/*
  * Copyright (C) 2013-2016 Open Whisper Systems
  *
  * Licensed according to the LICENSE file in this repository.
  */
 package org.whispersystems.libsignal.ecc;
 
+import java.security.KeyPair;
+
 public class ECKeyPair {
 
-  private final ECPublicKey  publicKey;
-  private final ECPrivateKey privateKey;
+  private final KeyPair keyPair;
 
   public ECKeyPair(ECPublicKey publicKey, ECPrivateKey privateKey) {
-    this.publicKey = publicKey;
-    this.privateKey = privateKey;
+    this.keyPair = new KeyPair(publicKey,privateKey);
+  }
+
+  public KeyPair getKeyPair() {
+    return this.keyPair;
   }
 
   public ECPublicKey getPublicKey() {
-    return publicKey;
+    return (ECPublicKey) this.keyPair.getPublic();
   }
 
   public ECPrivateKey getPrivateKey() {
-    return privateKey;
+    return (ECPrivateKey) this.keyPair.getPrivate();
   }
 }

--- a/java/src/main/java/org/whispersystems/libsignal/ecc/ECPrivateKey.java
+++ b/java/src/main/java/org/whispersystems/libsignal/ecc/ECPrivateKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2016 Open Whisper Systems
  *
  * Licensed according to the LICENSE file in this repository.
@@ -6,7 +6,9 @@
 
 package org.whispersystems.libsignal.ecc;
 
-public interface ECPrivateKey {
-  public byte[] serialize();
-  public int getType();
+import java.security.PrivateKey;
+
+public interface ECPrivateKey extends PrivateKey {
+  byte[] serialize();
+  int getType();
 }

--- a/java/src/main/java/org/whispersystems/libsignal/ecc/ECPublicKey.java
+++ b/java/src/main/java/org/whispersystems/libsignal/ecc/ECPublicKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2013-2016 Open Whisper Systems
  *
  * Licensed according to the LICENSE file in this repository.
@@ -6,11 +6,13 @@
 
 package org.whispersystems.libsignal.ecc;
 
-public interface ECPublicKey extends Comparable<ECPublicKey> {
+import java.security.PublicKey;
 
-  public static final int KEY_SIZE = 33;
+public interface ECPublicKey extends PublicKey, Comparable<ECPublicKey> {
 
-  public byte[] serialize();
+  int KEY_SIZE = 33;
 
-  public int getType();
+  byte[] serialize();
+
+  int getType();
 }


### PR DESCRIPTION
This PR makes the keys compatible with the Java framework by extending the PublicKey and PrivateKey interfaces.